### PR TITLE
Drop `epel-8` from the `packit` config

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -4,6 +4,5 @@ jobs:
     metadata:
         targets:
           - fedora-all
-          - epel-8
           - epel-9
         skip_build: true


### PR DESCRIPTION
`tmt` is no more supported on `el-8`.