### PR TITLE
Add a simple smoke plan for remote import testing

### DIFF
--- a/plans/remote.fmf
+++ b/plans/remote.fmf
@@ -1,0 +1,11 @@
+summary: A simple smoke plan for remote testing
+description:
+    This is just a simple smoke plan used for testing import of
+    remote plans. See the related test coverage for more details.
+discover:
+    how: fmf
+    filter: tag:remote
+execute:
+    how: tmt
+link:
+  - relates: https://github.com/teemtee/tmt/tree/main/tests/plan/import

--- a/tests/main.fmf
+++ b/tests/main.fmf
@@ -1,0 +1,8 @@
+tag: remote
+
+/one:
+    summary: Remote test one
+    test: echo one
+/two:
+    summary: Remote test two
+    test: echo two


### PR DESCRIPTION
Provide a trivial plan which can be referenced from the main `tmt` repository to verify the plan import functionality. To be used together with the `/tests/plan/import/*` tests.