### PR TITLE
Make sure `import` word is not present in `/plans/remote`

### DIFF
--- a/plans/remote.fmf
+++ b/plans/remote.fmf
@@ -1,6 +1,6 @@
 summary: A simple smoke plan for remote testing
 description:
-    This is just a simple smoke plan used for testing import of
+    This is just a simple smoke plan used for testing importing of
     remote plans. See the related test coverage for more details.
 discover:
     how: fmf


### PR DESCRIPTION
Trying to fix the error in
```
    rlPhaseStartTest "Show Plans (deep)"
        rlRun -s "tmt plan show"
        rlAssertNotGrep '\<import\>' $rlRun_LOG
```
From tmt tests. However this one is still failing I believe due to the:
https://github.com/teemtee/tests/blob/24e02d2063e08aef1176b912ade14c3375da2c9f/plans/remote.fmf#L11

Shall we just nuke that as well?